### PR TITLE
add persistence (working)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ _testmain.go
 *.exe
 
 present-switch
+presentswitch.db

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ go:
     - master
 
 stages:
+    - test
     - build
 
 jobs:
     include:
+        - stage: test
+          script: go test ./... -test.v
         - stage: build
           script: go build

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the repository and simply install the binaries (requires [Go](https://
 ```
 git clone https://github.com/ubuconeurope/present-switch
 cd present-switch/
-go build && ./present-switch
+go run main.go
 ```
 The server should then start listening on port `3000`.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Check out the repository and simply install the binaries (requires [Go](https://
 ```
 git clone https://github.com/ubuconeurope/present-switch
 cd present-switch/
-go run main.go
+go build && ./present-switch
 ```
 The server should then start listening on port `3000`.
 

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package presentswitch
+package main
 
 import (
 	"io/ioutil"

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-package main
+package presentswitch
 
 import (
 	"io/ioutil"

--- a/persistence.go
+++ b/persistence.go
@@ -1,4 +1,4 @@
-package presentswitch
+package main
 
 import (
 	"database/sql"
@@ -73,11 +73,11 @@ func StoreItem(db *sql.DB, item RoomInfo) {
 	}
 	defer stmt.Close()
 
-	_, err2 := stmt.Exec(item.ID, item.RoomName,
+	_, err = stmt.Exec(item.ID, item.RoomName,
 		item.CurrentTitle, item.CurrentSpeaker, item.CurrentTime,
 		item.NextTitle, item.NextSpeaker, item.NextTime)
-	if err2 != nil {
-		panic(err2)
+	if err != nil {
+		panic(err)
 
 	}
 }

--- a/persistence.go
+++ b/persistence.go
@@ -1,0 +1,131 @@
+package presentswitch
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Represents the current state of a RoomInfo.
+type RoomInfo struct {
+	ID             int // room number
+	RoomName       string
+	CurrentTitle   string
+	CurrentSpeaker string
+	CurrentTime    string
+	NextTitle      string
+	NextSpeaker    string
+	NextTime       string
+}
+
+// InitDB creates a new DB object using filename as parameter
+func InitDB(filepath string) *sql.DB {
+	db, err := sql.Open("sqlite3", filepath)
+	if err != nil {
+		panic(err)
+	}
+	if db == nil {
+		panic("db nil")
+	}
+	return db
+}
+
+// CreateTables create all tables needed.
+func CreateTables(db *sql.DB) {
+	// create table if not exists
+	sqlTable := `
+	CREATE TABLE IF NOT EXISTS room_info(
+		id INTEGER PRIMARY KEY,
+		room_name TEXT NOT NULL,
+		current_title TEXT NOT NULL,
+		current_speaker TEXT NOT NULL,
+		current_time TEXT NOT NULL,
+		next_title TEXT NOT NULL,
+		next_speaker TEXT NOT NULL,
+		next_time TEXT NOT NULL
+	);
+	`
+
+	_, err := db.Exec(sqlTable)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// StoreItem stores multiple items
+func StoreItem(db *sql.DB, item RoomInfo) {
+	sqlAdditem := `
+	INSERT OR REPLACE INTO room_info(
+		id,
+		room_name,
+		current_title,
+		current_speaker,
+		current_time,
+		next_title,
+		next_speaker,
+		next_time
+	) values(?, ?, ?, ?, ?, ?, ?, ?)
+	`
+
+	stmt, err := db.Prepare(sqlAdditem)
+	if err != nil {
+		panic(err)
+	}
+	defer stmt.Close()
+
+	_, err2 := stmt.Exec(item.ID, item.RoomName,
+		item.CurrentTitle, item.CurrentSpeaker, item.CurrentTime,
+		item.NextTitle, item.NextSpeaker, item.NextTime)
+	if err2 != nil {
+		panic(err2)
+
+	}
+}
+
+// ReadRoomInfoTable reads all rows in the room_info table
+func ReadRoomInfoTable(db *sql.DB) []RoomInfo {
+	sqlReadall := `
+	SELECT * FROM room_info
+	ORDER BY id DESC
+	`
+
+	rows, err := db.Query(sqlReadall)
+	if err != nil {
+		panic(err)
+	}
+	defer rows.Close()
+
+	var result []RoomInfo
+	for rows.Next() {
+		item := RoomInfo{}
+		err2 := rows.Scan(&item.ID, &item.RoomName,
+			&item.CurrentTitle, &item.CurrentSpeaker, &item.CurrentTime,
+			&item.NextTitle, &item.NextSpeaker, &item.NextTime)
+		if err2 != nil {
+			panic(err2)
+		}
+		result = append(result, item)
+	}
+	return result
+}
+
+// ReadRoomInfo read one row, with the row ID
+func ReadRoomInfo(db *sql.DB, id int) (RoomInfo, error) {
+	sqlRead := `
+	SELECT * FROM room_info
+	WHERE id = ?
+	`
+
+	stmt, err := db.Prepare(sqlRead)
+	if err != nil {
+		panic(err)
+	}
+	defer stmt.Close()
+
+	var item RoomInfo
+	err = stmt.QueryRow(id).Scan(&item.ID, &item.RoomName,
+		&item.CurrentTitle, &item.CurrentSpeaker, &item.CurrentTime,
+		&item.NextTitle, &item.NextSpeaker, &item.NextTime)
+
+	return item, err
+}

--- a/persistence.go
+++ b/persistence.go
@@ -98,11 +98,11 @@ func ReadRoomInfoTable(db *sql.DB) []RoomInfo {
 	var result []RoomInfo
 	for rows.Next() {
 		item := RoomInfo{}
-		err2 := rows.Scan(&item.ID, &item.RoomName,
+		err = rows.Scan(&item.ID, &item.RoomName,
 			&item.CurrentTitle, &item.CurrentSpeaker, &item.CurrentTime,
 			&item.NextTitle, &item.NextSpeaker, &item.NextTime)
-		if err2 != nil {
-			panic(err2)
+		if err != nil {
+			panic(err)
 		}
 		result = append(result, item)
 	}

--- a/persistence.go
+++ b/persistence.go
@@ -8,14 +8,14 @@ import (
 
 // Represents the current state of a RoomInfo.
 type RoomInfo struct {
-	ID             int // room number
-	RoomName       string
-	CurrentTitle   string
-	CurrentSpeaker string
-	CurrentTime    string
-	NextTitle      string
-	NextSpeaker    string
-	NextTime       string
+	ID             int    `json:"room_id"` // room number
+	RoomName       string `json:"room"`
+	CurrentTitle   string `json:"title"`
+	CurrentSpeaker string `json:"speaker"`
+	CurrentTime    string `json:"time"`
+	NextTitle      string `json:"n_title"`
+	NextSpeaker    string `json:"n_speaker"`
+	NextTime       string `json:"n_time"`
 }
 
 // InitDB creates a new DB object using filename as parameter

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -1,4 +1,4 @@
-package presentswitch
+package main
 
 import (
 	"os"

--- a/persistence_test.go
+++ b/persistence_test.go
@@ -1,0 +1,78 @@
+package presentswitch
+
+import (
+	"os"
+	"testing"
+)
+
+// All tests in the same tests because I need state and it is easier
+func TestAllPersistence(t *testing.T) {
+	const dbpath = "foo.db"
+	var readItems []RoomInfo
+	var (
+		readSingleItem RoomInfo
+		err            error
+	)
+
+	// test 0 - init db
+	db := InitDB(dbpath)
+	defer db.Close()
+	defer os.Remove(dbpath)
+
+	// test 1 - create tables
+	CreateTables(db)
+	t.Log("TestAllPersistence - TEST1 - CreateTables - OK")
+
+	// test 2 - insert data
+	StoreItem(db, RoomInfo{1, "Room1", "CurrTitle", "CurrSpeaker", "CurrTime", "NextTitle", "NextSpeaker", "NextTime"})
+
+	readItems = ReadRoomInfoTable(db)
+	if 1 != len(readItems) {
+		t.Errorf("Number of rows did not match the expected number 1")
+	}
+
+	// test 2.1 - insert more data
+	StoreItem(db, RoomInfo{2, "Room2", "CurrTitle", "CurrSpeaker", "CurrTime", "NextTitle", "NextSpeaker", "NextTime"})
+	StoreItem(db, RoomInfo{3, "Room4", "CurrTitle", "CurrSpeaker", "CurrTime", "NextTitle", "NextSpeaker", "NextTime"})
+	StoreItem(db, RoomInfo{4, "Room4", "CurrTitle", "CurrSpeaker", "CurrTime", "NextTitle", "NextSpeaker", "NextTime"})
+
+	readItems = ReadRoomInfoTable(db)
+	if 4 != len(readItems) {
+		t.Errorf("Number of rows did not match the expected number 1")
+	}
+	t.Log("TestAllPersistence - TEST2 - insert data - ", len(readItems), "(<-- 4 is expected)")
+
+	// test 3 - retrieve single data
+	readSingleItem, err = ReadRoomInfo(db, 2)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	if "Room2" != readSingleItem.RoomName {
+		t.Errorf("Unexpected RoomName: %s", readSingleItem.RoomName)
+	}
+	t.Log("TestAllPersistence - TEST3 - retrieve single data - ", readSingleItem)
+
+	// test 4 - retrieve unexisting data
+	readSingleItem, err = ReadRoomInfo(db, 99)
+	if err != nil {
+		// simple error is nice here.
+		if err.Error() != "sql: no rows in result set" {
+			t.Error("Unexpected error: ", err)
+		}
+	}
+	t.Log("TestAllPersistence - TEST4 - retrieve unexisting data - ", err)
+
+	// test 5 - update row
+	StoreItem(db, RoomInfo{2, "Room2", "Another Title Here", "", "", "", "", ""})
+	readSingleItem, err = ReadRoomInfo(db, 2)
+	if err != nil {
+		t.Error(err)
+		t.Fail()
+	}
+	if "Another Title Here" != readSingleItem.CurrentTitle {
+		t.Errorf("Unexpected RoomName: %s", readSingleItem.RoomName)
+	}
+	t.Log("TestAllPersistence - TEST5 - update row - ", readSingleItem)
+
+}


### PR DESCRIPTION
Continues the https://github.com/ubuconeurope/present-switch/pull/18
In the context of #17 

Add persistence.

* use sqlite driver - simpler, we don't need to address performance (yet)
* RoomInfo type struct
* methods for insert/update RoomInfo
* methods for retrieving RoomInfo, by room ID
* tests for this persistence module 
* update readme
* update travis cicd to include this tests
* handle GET
* handle POST

Adds persistence to the main command. Upon new connection, the client will get the last available information.
There are some issues with caching (if the browser do GET nothing, ghis will not work)