### PR TITLE
Ft BasicAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Via curl:
 curl -X POST -H 'Content-Type: application/json'  "http://localhost:3000/rooms/1" -d '{"room": "Master Room", "title": "Presentation Title", "speaker": "Speaker Name", "time": "00:01", "n_title": "This is the Title of the Next Presentation", "n_speaker": "Another Speaker", "n_time": "23:59"}'
 ```
 
+If you set the environment variables `ROOMS_AUTH_USERNAME` and `ROOMS_AUTH_PASSWORD`, 
+this admin pages are protected with BasicAuth
+
+
 ## Admin page
 
 You may update RoomInfo using the `admin` interface (instead of curl)
@@ -40,7 +44,7 @@ You may admin the room #1 through http://localhost:3000/admin/1/
 
 You may update all information available through the API (curl) and control the slides.
 
-If you set the environment variables `AUTH_USERNAME` and `AUTH_PASSWORD`, 
+If you set the environment variables `ADMIN_AUTH_USERNAME` and `ADMIN_AUTH_PASSWORD`, 
 this admin pages are protected with BasicAuth
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ The goal of this project is to allow automated triggering of content into HTTP c
 
 Ultimately, this allows having multiple clients listening to different URLs for specific content and allows you to change the room's content remotely or automatically (if you create a bot). 
 
-At Ubucon Europe 2019, we will have 4 rooms to manage, each with their own schedule and non-overlapping terms. This server allows some clients to connect and we can change the content of the template by calling a POST method against the API with a body like `body.go`. Provided we will have an iCal calendar, we can automate this process by building another bot that will trigger the HTTP events on time, thus dynamically changing the room's displayed text.
+At Ubucon Europe 2019, we will have 4 rooms to manage, each with their own schedule and non-overlapping terms. This server allows some clients to connect and we can change the content of the template by calling a POST method against the API. Provided we will have an iCal calendar, we can automate this process by building another bot that will trigger the HTTP events on time, thus dynamically changing the room's displayed text.
+
+You may also change the slides (next/previous slide) using the admin interface (remote control).
 
 ## Running
 
@@ -18,13 +20,28 @@ go build && ./present-switch
 ```
 The server should then start listening on port `3000`.
 
-Then: 
+
+## Using
+
+Open your browser at http://localhost:3000/rooms/1/
+
+Then, you may change the information with the API via curl, or via [Admin page](#admin-page)
+
+Via curl:
+
 ```
-1) Open your browser at http://localhost:3000/rooms/1/ (do not forget the last /)
-2) curl -X POST -H 'Content-Type: application/json'  "http://localhost:3000/rooms/1" -d '{"room": "Master Room", "title": "Presentation Title", "speaker": "Speaker Name", "time": "00:01", "n_title": "This is the Title of the Next Presentation", "n_speaker": "Another Speaker", "n_time": "23:59"}'
-3) You may try with any other room number. They should stay independent
+curl -X POST -H 'Content-Type: application/json'  "http://localhost:3000/rooms/1" -d '{"room": "Master Room", "title": "Presentation Title", "speaker": "Speaker Name", "time": "00:01", "n_title": "This is the Title of the Next Presentation", "n_speaker": "Another Speaker", "n_time": "23:59"}'
 ```
 
+## Admin page
+
+You may update RoomInfo using the `admin` interface (instead of curl)
+You may admin the room #1 through http://localhost:3000/admin/1/ 
+
+You may update all information available through the API (curl) and control the slides.
+
+If you set the environment variables `AUTH_USERNAME` and `AUTH_PASSWORD`, 
+this admin pages are protected with BasicAuth
 
 
 ## Contributing


### PR DESCRIPTION
Allow an opcional BasicAuth for roomInfo updates, in order to avoid unintended updates from random sources :smile: 
This credentials are set using Environment Variables. 

There are two different BasicAuth credentials:
 - /rooms/ (ROOMS_AUTH_USERNAME | ROOMS_AUTH_PASSWORD)
 - /admin/ (ADMIN_AUTH_USERNAME | ADMIN_AUTH_PASSWORD)

You may test it like:
```
go build   &&   ROOMS_AUTH_USERNAME=usertoken  ROOMS_AUTH_PASSWORD=passtoken ADMIN_AUTH_USERNAME=admin ADMIN_AUTH_PASSWORD=admpass   ./present-switch
```

Then:
- first, open a client browser: http://localhost:3000/rooms/1 
- admin: Open your browser (creds=> admin admpass): http://localhost:3000/admin/1
- POST: use a curl with BasicAuth (`http://usertoken:passtoken@localhost...`):
  ```
  curl -X POST -H 'Content-Type: application/json' "http://usertoken:passtoken@localhost:3000/rooms/1" -d '{"room": "Master Room", "title": "Presentation Title", "speaker": "Speaker Name", "time": "00:01", "n_title": "This is the Title of the Next Presentation", "n_speaker": "Another Speaker", "n_time": "23:59"}'
  ```
